### PR TITLE
Check that line is numeric

### DIFF
--- a/script.clj
+++ b/script.clj
@@ -27,7 +27,7 @@
    return a {:file :line :col :linter+msg} map, or nil"
   [directory s]
   (let [[file line col linter+msg] (str/split s #":" 4)]
-    (when linter+msg
+    (when (and linter+msg (re-matches #"\d+" line))
       {:file (.getAbsolutePath (io/file directory file))
        :line (Integer/parseInt line)
        :col  (Integer/parseInt col)


### PR DESCRIPTION
Creating hints fails if an output line matches the hint pattern, but the line can not be parsed to integer. 

In my case, failures were caused by lines such as:

```
WARNING: update already refers to: #'clojure.core/update in namespace: monger.collection, being replaced by: #'monger.collection/update

jar:file:/C:/Users/juhajo/.m2/repository/noir/noir/1.3.0/noir-1.3.0.jar!/noir/server.clj:80:3: Reflection warning - reference to field stop can't be resolved.
```

Also, any logging to stdout in the evaluated code might cause similar problems.
